### PR TITLE
Missed name setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There are several configuration settings supported:
 | `description`         | No       | The description value for the nuget package metadata. Defaults to the `description` field from your app's package.json file when unspecified. |
 | `version`             | No       | The version value for the nuget package metadata. Defaults to the `version` field from your app's package.json file when unspecified. |
 | `title`               | No       | The title value for the nuget package metadata. Defaults to the `productName` field and then the `name` field from your app's package.json file when unspecified. |
+| `name`                | No      | Windows Application Model ID (appId). Defaults to the `name` field in your app's package.json file. |
 | `certificateFile`     | No       | The path to an Authenticode Code Signing Certificate |
 | `certificatePassword` | No       | The password to decrypt the certificate given in `certificateFile` |
 | `signWithParams`      | No       | Params to pass to signtool.  Overrides `certificateFile` and `certificatePassword`. |


### PR DESCRIPTION
I've been looking for a way to override windows `appId` (to set final directory for my app in `%user%/AppData/Local/<name>`). And found that there is a `name` option that do this, but it was missed in README.
